### PR TITLE
[EAM-426] Fixed checklist notes/checklist follow up checkbox

### DIFF
--- a/dist/ui/components/checklists/ChecklistItemFollowUp.js
+++ b/dist/ui/components/checklists/ChecklistItemFollowUp.js
@@ -72,8 +72,9 @@ function (_Component) {
     };
 
     _this.handleChange = function (event) {
+      // invert the input since we are using an onMouseDown/onTouchStart handler, before the input is changed
       _this.props.onChange(_objectSpread({}, _this.props.checklistItem, {
-        followUp: event.target.checked
+        followUp: !event.target.checked
       }));
     };
 
@@ -102,7 +103,8 @@ function (_Component) {
           color: "primary",
           checked: checklistItem.followUp === '+' || checklistItem.followUp === true,
           disabled: Boolean(checklistItem.followUpWorkOrder),
-          onChange: this.handleChange
+          onMouseDown: this.handleChange,
+          onTouchStart: this.handleChange
         }),
         labelPlacement: "start",
         label: "Follow-up"

--- a/dist/ui/components/checklists/ChecklistItemNotes.js
+++ b/dist/ui/components/checklists/ChecklistItemNotes.js
@@ -101,15 +101,6 @@ function (_Component) {
       }
     }
   }, {
-    key: "componentWillReceiveProps",
-    value: function componentWillReceiveProps(nextProps) {
-      if (nextProps.checklistItem) {
-        this.setState({
-          value: nextProps.checklistItem.notes
-        });
-      }
-    }
-  }, {
     key: "focus",
     value: function focus() {
       this.input.current.focus();

--- a/src/ui/components/checklists/ChecklistItemFollowUp.js
+++ b/src/ui/components/checklists/ChecklistItemFollowUp.js
@@ -18,9 +18,10 @@ export default class ChecklistItemFollowUp extends Component {
     }
 
     handleChange = event => {
+        // invert the input since we are using an onMouseDown/onTouchStart handler, before the input is changed
         this.props.onChange({
             ...this.props.checklistItem,
-            followUp: event.target.checked
+            followUp: !event.target.checked
         })
     }
 
@@ -41,7 +42,8 @@ export default class ChecklistItemFollowUp extends Component {
                                 color="primary"
                                 checked={checklistItem.followUp === '+' || checklistItem.followUp === true}
                                 disabled={Boolean(checklistItem.followUpWorkOrder)}
-                                onChange={this.handleChange}/>
+                                onMouseDown={this.handleChange}
+                                onTouchStart={this.handleChange} />
                         }
                         labelPlacement='start'
                         label={"Follow-up"}

--- a/src/ui/components/checklists/ChecklistItemNotes.js
+++ b/src/ui/components/checklists/ChecklistItemNotes.js
@@ -15,14 +15,6 @@ export default class ChecklistItemNotes extends Component {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.checklistItem) {
-            this.setState({
-                value: nextProps.checklistItem.notes
-            })
-        }
-    }
-
     mainDivStyle = {
         padding: 2,
         position: "relative",


### PR DESCRIPTION
This issue was caused by the onBlur event of the checklist notes rerendering the page, causing the onChange handler of the checkbox not firing. This would also possibly happen for other onBlur handlers that call setState and rerender the page.

Changing the event of the checkbox to onMouseDown/onTouchStart ensures it is fired first, and then the onBlur. This resulted in another problem: the checklist item state would be changed, which updated the props of the notes and in turn updated the notes, to what they were before the user started editing them. As discussed, removing the method that updates these notes fixes this problem, but removes the possibility of updating the notes component from outside.

Related PR: https://github.com/cern-eam/eam-light-frontend/pull/36