### PR TITLE
[EAM-1918] Pass down inputProps to EAMTextField

### DIFF
--- a/dist/ui/components/muiinputs/EAMInput.js
+++ b/dist/ui/components/muiinputs/EAMInput.js
@@ -80,7 +80,9 @@ var EAMInput = /*#__PURE__*/function (_EAMBaseInput) {
     value: function renderComponent() {
       var _this2 = this;
 
-      var elementInfo = this.props.elementInfo;
+      var _this$props = this.props,
+          elementInfo = _this$props.elementInfo,
+          inputProps = _this$props.inputProps;
       return /*#__PURE__*/React.createElement(EAMTextField, _extends({
         disabled: this.state.disabled || elementInfo && elementInfo.readonly,
         error: this.state.error,
@@ -94,7 +96,8 @@ var EAMInput = /*#__PURE__*/function (_EAMBaseInput) {
         onBlur: this.onLoseFocus,
         InputLabelProps: {
           shrink: true
-        }
+        },
+        inputProps: inputProps
       }, this.generateInputProps(this.props)));
     }
   }]);

--- a/src/ui/components/muiinputs/EAMInput.js
+++ b/src/ui/components/muiinputs/EAMInput.js
@@ -27,7 +27,7 @@ class EAMInput extends EAMBaseInput {
 
 
     renderComponent () {
-        const { elementInfo } = this.props;
+        const { elementInfo, inputProps } = this.props;
 
         return (
             <EAMTextField
@@ -40,6 +40,7 @@ class EAMInput extends EAMBaseInput {
                 onChange={event => this.setValue(event.target.value)}
                 onBlur={this.onLoseFocus}
                 InputLabelProps={{ shrink: true }}
+                inputProps={inputProps}
                 {...this.generateInputProps(this.props)}/>
         )
     }


### PR DESCRIPTION
Doing this allows passing attributes such as 'maxLength' for inputs.

Related to https://github.com/cern-eam/eam-light-frontend/pull/148