### PR TITLE
[EAM-2262] Add Does Not Contain to grid filters

### DIFF
--- a/dist/ui/components/grids/eam/utils.js
+++ b/dist/ui/components/grids/eam/utils.js
@@ -29,7 +29,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 import React, { useState } from "react";
 import { TextField, Checkbox, MenuItem, ListItemIcon, ListItemText, Menu, IconButton, InputAdornment, Select, InputBase } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
-import { ContainStart, ContainEnd, Contain, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Equal, NotEqualVariant, Rhombus, RhombusOutline } from 'mdi-material-ui';
+import { ContainStart, ContainEnd, Contain, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Equal, NotEqualVariant, Rhombus, RhombusOutline, MinusCircleOffOutline } from 'mdi-material-ui';
 import { DatePicker, DateTimePicker } from "@mui/x-date-pickers";
 import { Clear as ClearIcon, InsertInvitation as CalendarIcon } from "@mui/icons-material";
 import { useAsyncDebounce, useMountedLayoutEffect } from "react-table";
@@ -89,7 +89,8 @@ var OPERATORS = {
   IS_EMPTY: 'IS EMPTY',
   LESS_THAN: 'LESS_THAN',
   LESS_THAN_EQUALS: 'LESS_THAN_EQUALS',
-  NOT_EMPTY: 'NOT EMPTY'
+  NOT_EMPTY: 'NOT EMPTY',
+  NOT_CONTAINS: 'NOTCONTAINS'
 };
 var CHECKBOX_FILTERS = {
   CHECKED: -1,
@@ -152,6 +153,10 @@ var getEAMFilterOperators = function getEAMFilterOperators(_ref) {
         'value': OPERATORS.ENDS,
         'label': 'Ends with',
         'icon': /*#__PURE__*/React.createElement(ContainEnd, null)
+      }, {
+        'value': OPERATORS.NOT_CONTAINS,
+        'label': 'Does Not Contain',
+        'icon': /*#__PURE__*/React.createElement(MinusCircleOffOutline, null)
       }, {
         'value': OPERATORS.EQUAL,
         'label': 'Equals',

--- a/src/ui/components/grids/eam/utils.js
+++ b/src/ui/components/grids/eam/utils.js
@@ -23,7 +23,8 @@ import {
     Equal,
     NotEqualVariant,
     Rhombus,
-    RhombusOutline
+    RhombusOutline,
+    MinusCircleOffOutline,
 } from 'mdi-material-ui';
 import { DatePicker, DateTimePicker } from "@mui/x-date-pickers";
 import {
@@ -91,6 +92,7 @@ const OPERATORS = {
     LESS_THAN: 'LESS_THAN',
     LESS_THAN_EQUALS: 'LESS_THAN_EQUALS',
     NOT_EMPTY: 'NOT EMPTY',
+    NOT_CONTAINS: 'NOTCONTAINS',
 }
 
 const CHECKBOX_FILTERS = {
@@ -138,6 +140,7 @@ const getEAMFilterOperators = ({ column }) => {
                 {'value': OPERATORS.BEGINS, 'label': 'Starts with', 'icon': <ContainStart/>},
                 {'value': OPERATORS.CONTAINS, 'label': 'Contains', 'icon': <Contain/>},
                 {'value': OPERATORS.ENDS, 'label': 'Ends with', 'icon': <ContainEnd/>},
+                {'value': OPERATORS.NOT_CONTAINS, 'label': 'Does Not Contain', 'icon': <MinusCircleOffOutline/>},
                 {'value': OPERATORS.EQUAL, 'label': 'Equals', 'icon': <Equal/>},
                 {'value': OPERATORS.NOT_EQUAL, 'label': 'Does not equal', 'icon': <NotEqualVariant/>},
                 {'value': OPERATORS.IS_EMPTY, 'label': 'Is empty', 'icon': <RhombusOutline/>},


### PR DESCRIPTION
I could not find a not contains icon so I used one that fit the styling and at least kind of conveys the message: `MinusCircleOffOutline`