### PR TITLE
[EAM-2446] Add multiple autocomplete support (WIP); Update createOnChangeHandler helper and add one to handle object updates

### DIFF
--- a/dist/ui/components/inputs-ng/EAMTextField.js
+++ b/dist/ui/components/inputs-ng/EAMTextField.js
@@ -13,7 +13,8 @@ var EAMTextField = function EAMTextField(props) {
   var value = props.value,
     onChange = props.onChange,
     onChangeInput = props.onChangeInput,
-    validator = props.validator;
+    validator = props.validator,
+    _onBlur = props.onBlur;
   var _useState = useState(value || ''),
     _useState2 = _slicedToArray(_useState, 2),
     inputValue = _useState2[0],
@@ -28,7 +29,7 @@ var EAMTextField = function EAMTextField(props) {
       setInputValue(event.target.value);
       onChangeInput?.(event.target.value);
     },
-    onBlur: function onBlur() {
+    onBlur: function onBlur(event) {
       if (inputValue !== value) {
         if (!validator || validator(inputValue)) {
           onChange?.(inputValue);
@@ -36,6 +37,7 @@ var EAMTextField = function EAMTextField(props) {
           setInputValue(value);
         }
       }
+      _onBlur?.(event);
     },
     value: inputValue
   };

--- a/dist/ui/components/inputs-ng/tools/input-tools.js
+++ b/dist/ui/components/inputs-ng/tools/input-tools.js
@@ -1,3 +1,14 @@
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 import isEqual from 'lodash/isEqual';
@@ -80,22 +91,76 @@ export var componentsProps = {
     elevation: 4
   }
 };
-export var createOnChangeHandler = function createOnChangeHandler(valueKey, descKey, orgKey, updateEntityProperty, onChange) {
+
+/**
+ * Use this function when the passed updating function expects a key and a
+ * value as the first two arguments.
+ * @param additionalFunctionArgs is an array of arguments that will be spread
+ * and passed to the end of the updating function's arguments. This enables
+ * passing more arguments to the updating function than just the key and value.
+ */
+export var createOnChangeHandler = function createOnChangeHandler(valueKey, descKey, orgKey, updatingFunction, onChange) {
+  var additionalArgs = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : [];
   return function (value) {
+    // When receiving an object value, we run the updating function for each
+    // key that was passed.
     if (_typeof(value) === 'object') {
       if (value.code !== undefined) {
-        updateEntityProperty?.(valueKey, value.code);
+        updatingFunction?.(valueKey, value.code, ...additionalArgs);
         onChange?.(value.code);
       }
       if (descKey && value.desc !== undefined) {
-        updateEntityProperty(descKey, value.desc);
+        updatingFunction.apply(void 0, [descKey, value.desc].concat(_toConsumableArray(additionalArgs)));
       }
       if (orgKey && value.organization !== undefined) {
-        updateEntityProperty(orgKey, value.organization);
+        updatingFunction.apply(void 0, [orgKey, value.organization].concat(_toConsumableArray(additionalArgs)));
       }
     } else {
-      updateEntityProperty?.(valueKey, value);
+      // When receiving a non-object value, we assume it corresponds to
+      // the value key.
+      updatingFunction?.(valueKey, value, ...additionalArgs);
       onChange?.(value);
+
+      // Reset the description and org if the respective key was passed to
+      // the function, thus clearing the field of previous values that do
+      // not match the value picked.
+      if (descKey) {
+        updatingFunction.apply(void 0, [descKey, ''].concat(_toConsumableArray(additionalArgs)));
+      }
+      if (orgKey) {
+        updatingFunction.apply(void 0, [orgKey, ''].concat(_toConsumableArray(additionalArgs)));
+      }
+    }
+  };
+};
+
+/**
+ * Use this function when the passed updating function expects an object as its
+ * first argument (as opposed to a key and a value arguments). Note that, in
+ * this function we check the values against undefined so that empty string
+ * values are not ignored, thus allowing for fields to be cleared.
+ * @param additionalFunctionArgs is an array of arguments that will be spread
+ * and passed to the end of the updating function's arguments. This enables
+ * passing more arguments to the updating function than just the object
+ * containing all key-value pairs.
+ * */
+export var createOnChangeHandlerObjectUpdate = function createOnChangeHandlerObjectUpdate(valueKey, descKey, orgKey, updatingFunction, onChange) {
+  var additionalArgs = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : [];
+  return function (value) {
+    if (_typeof(value) === 'object') {
+      var updateObject = _objectSpread({}, value.code !== undefined && _defineProperty({}, valueKey, value.code), {}, value.desc !== undefined && _defineProperty({}, descKey, value.desc), {}, value.organization !== undefined && _defineProperty({}, orgKey, value.organization));
+      updatingFunction?.(updateObject, ...additionalArgs);
+      onChange?.(updateObject);
+    } else {
+      // If we are expecting an object update, but we get a non-object
+      // value (can happen on a barcode scan), we set the value key to the
+      // value received since that is expected to be the selected option.
+      // Additionally, we reset the description and org if the respective
+      // key was passed to the function, thus clearing the field of
+      // previous values that do not match the value selected.
+      var _updateObject = _objectSpread(_defineProperty({}, valueKey, value), descKey && _defineProperty({}, descKey, ''), {}, orgKey && _defineProperty({}, orgKey, ''));
+      updatingFunction?.(_updateObject, ...additionalArgs);
+      onChange?.(_updateObject);
     }
   };
 };

--- a/dist/ui/components/inputs-ng/wip/EAMAutocomplete.js
+++ b/dist/ui/components/inputs-ng/wip/EAMAutocomplete.js
@@ -1,0 +1,170 @@
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _iterableToArrayLimit(arr, i) { var _i = null == arr ? null : "undefined" != typeof Symbol && arr[Symbol.iterator] || arr["@@iterator"]; if (null != _i) { var _s, _e, _x, _r, _arr = [], _n = !0, _d = !1; try { if (_x = (_i = _i.call(arr)).next, 0 === i) { if (Object(_i) !== _i) return; _n = !1; } else for (; !(_n = (_s = _x.call(_i)).done) && (_arr.push(_s.value), _arr.length !== i); _n = !0); } catch (err) { _d = !0, _e = err; } finally { try { if (!_n && null != _i["return"] && (_r = _i["return"](), Object(_r) !== _r)) return; } finally { if (_d) throw _e; } } return _arr; } }
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+import React, { useState } from 'react';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import useFetchAutocompleteOptions from '../hooks/useFetchAutocompleteOptions';
+import { areEqual, componentsProps, renderOptionHandler } from '../tools/input-tools';
+import EAMBaseInput from '../components/EAMBaseInput';
+import TextField from './TextField';
+import { saveHistory, HISTORY_ID_PREFIX } from '../tools/history-tools';
+import Chip from '@mui/material/Chip';
+var filter = createFilterOptions();
+
+// TODO: this component is an extension of the EAMAutocomplete that supports
+// multiple values. Although it is expected to still work the same for single
+// values, it should be re-tested with them to make sure it still works as before.
+var EAMAutocomplete = function EAMAutocomplete(props) {
+  // NOTE: the 'multiple' and 'tagLabelKey' props is not in the non-wip version
+  var autocompleteHandler = props.autocompleteHandler,
+    autocompleteHandlerParams = props.autocompleteHandlerParams,
+    value = props.value,
+    desc = props.desc,
+    id = props.id,
+    renderValue = props.renderValue,
+    onChange = props.onChange,
+    multiple = props.multiple,
+    tagLabelKey = props.tagLabelKey,
+    creatable = props.creatable;
+
+  // NOTE: this logic is not in the non-wip version
+  var optionValueKey = tagLabelKey ? tagLabelKey : 'code';
+  var _useState = useState(''),
+    _useState2 = _slicedToArray(_useState, 2),
+    inputValue = _useState2[0],
+    setInputValue = _useState2[1];
+  var _useState3 = useState(false),
+    _useState4 = _slicedToArray(_useState3, 2),
+    open = _useState4[0],
+    setOpen = _useState4[1];
+  var _useFetchAutocomplete = useFetchAutocompleteOptions(autocompleteHandler, autocompleteHandlerParams, inputValue, value, open, id),
+    _useFetchAutocomplete2 = _slicedToArray(_useFetchAutocomplete, 2),
+    fetchedOptions = _useFetchAutocomplete2[0],
+    loading = _useFetchAutocomplete2[1];
+  var getOptionLabelHandler = function getOptionLabelHandler(option) {
+    // NOTE: we adapt if the option object is not using 'code'
+    return option[optionValueKey] ?? option;
+  };
+  var onInputChangeHandler = function onInputChangeHandler(event, newInputValue) {
+    setInputValue(newInputValue);
+    if (newInputValue !== value && desc) {
+      onChange({
+        desc: ''
+      });
+    }
+  };
+  var onChangeHandler = function onChangeHandler(event, newValue, reason) {
+    if (reason === 'clear' || reason === 'createOption') {
+      // Cases handled by the onCloseHandler
+      return;
+    }
+    saveHistory(HISTORY_ID_PREFIX + id, newValue.code, newValue.desc);
+    onChange(newValue);
+
+    // Don't bubble up any events (won't trigger a save when we select something by pressing enter)
+    event.stopPropagation();
+    event.preventDefault();
+  };
+  var onCloseHandler = function onCloseHandler(event, reason) {
+    setOpen(false);
+    // Only to be fired when we blur, press ESC or hit enter and the
+    // inputValue is different than the original value
+    if (['blur', 'escape', 'createOption'].includes(reason) && inputValue !== value && !multiple // avoids adding a tag // NOTE: this is not in the non-wip version
+    ) {
+      // TODO: validation if inputValue is not empty
+      onChange({
+        code: inputValue
+      });
+    }
+  };
+
+  // NOTE: this handler is not in the non-wip version
+  var filterOptionsHandler = function filterOptionsHandler(options, params) {
+    if (!creatable) {
+      return options;
+    }
+    var inputValue = params.inputValue;
+
+    // Disallow adding the same option twice
+    if (value.some(function (option) {
+      return option[optionValueKey] === inputValue;
+    })) {
+      return [];
+    }
+
+    // check if input value is in the suggested options
+    var exists = options.some(function (option) {
+      return inputValue === (optionValueKey ? option[optionValueKey] : option);
+    });
+    var filtered = filter(options, params);
+
+    // if not, add it to the suggestions list
+    if (inputValue !== '' && !exists) {
+      var _filtered$push;
+      filtered.push((_filtered$push = {}, _defineProperty(_filtered$push, optionValueKey, inputValue), _defineProperty(_filtered$push, "desc", "Add \"".concat(inputValue, "\"")), _filtered$push));
+    }
+    return filtered;
+  };
+  return /*#__PURE__*/React.createElement(EAMBaseInput, props, /*#__PURE__*/React.createElement(Autocomplete
+  // Options
+  , {
+    options: fetchedOptions,
+    getOptionLabel: getOptionLabelHandler,
+    renderOption: renderOptionHandler.bind(null, renderValue)
+    // Open props
+    ,
+    open: open,
+    onOpen: function onOpen() {
+      return setOpen(true);
+    },
+    onClose: onCloseHandler
+    // On change
+    ,
+    onChange: onChangeHandler,
+    onInputChange: onInputChangeHandler
+    // Misc
+    ,
+    filterOptions: filterOptionsHandler // NOTE: this prop is different in the non-wip version
+    ,
+    id: id,
+    freeSolo: true,
+    multiple: multiple // NOTE: this prop is not in the non-wip version
+    ,
+    value: value ? value : multiple ? undefined : '' // NOTE: this cond is not in the non-wip version
+    // NOTE: this prop is not in the non-wip version
+    ,
+    renderTags: function renderTags(value, getTagProps) {
+      return value.map(function (option, index) {
+        return /*#__PURE__*/React.createElement(Chip, _extends({
+          variant: "outlined",
+          label: optionValueKey ? option[optionValueKey] : option
+        }, getTagProps({
+          index: index
+        })));
+      });
+    }
+    // Visuals
+    ,
+    openOnFocus: true // Very important, otherwise onCloseHandler won't be fired for example when we focus a field with a tab and delete its value.
+    // Funningly without this prop it still works correctly when we manually gain focus using the mouse.
+    ,
+    componentsProps: componentsProps,
+    includeInputInList: true,
+    loading: loading,
+    size: "small",
+    fullWidth: true,
+    renderInput: function renderInput(params) {
+      return /*#__PURE__*/React.createElement(TextField, _extends({}, params, props));
+    }
+  }));
+};
+EAMAutocomplete.defaultProps = {};
+export default React.memo(EAMAutocomplete, areEqual);

--- a/dist/ui/components/inputs-ng/wip/TextField.js
+++ b/dist/ui/components/inputs-ng/wip/TextField.js
@@ -1,0 +1,93 @@
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+import React from 'react';
+import EAMBarcodeScanner from '../components/EAMBarcodeScanner';
+import EAMLink from '../components/EAMLink';
+import TextFieldInput from './TextFieldInput';
+import TextFieldTextAdornment from '../components/TextFieldTextAdornment';
+import TextFieldDescription from '../components/TextFieldDescription';
+var divInputStyle = {
+  flex: "1 1 auto",
+  position: "relative"
+};
+var divInputContainerStyle = {
+  flex: "1 1 auto",
+  display: "flex",
+  alignItems: "center"
+};
+var divRootContainerStyle = {
+  flex: "1 1 auto",
+  display: "flex",
+  flexDirection: "column"
+};
+var divErrorStyle = {
+  margin: 3,
+  color: "red",
+  fontSize: 12
+};
+var TextField = function TextField(props) {
+  var desc = props.desc,
+    value = props.value,
+    barcodeScanner = props.barcodeScanner,
+    link = props.link,
+    onChange = props.onChange,
+    inputProps = props.inputProps,
+    inputRef = props.inputRef,
+    endTextAdornment = props.endTextAdornment,
+    endAdornment = props.endAdornment,
+    hideDescription = props.hideDescription,
+    disabled = props.disabled,
+    maxLength = props.maxLength,
+    uppercase = props.uppercase,
+    errorText = props.errorText,
+    style = props.style,
+    type = props.type;
+  var onInputUpperCaseHandler = function onInputUpperCaseHandler(event) {
+    var input = event.target;
+    var start = input.selectionStart;
+    var end = input.selectionEnd;
+    input.value = input.value.toLocaleUpperCase();
+    input.setSelectionRange(start, end);
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    style: _objectSpread({}, divRootContainerStyle, {}, style)
+  }, /*#__PURE__*/React.createElement("div", {
+    style: divInputContainerStyle
+  }, /*#__PURE__*/React.createElement("div", {
+    style: divInputStyle,
+    ref: props.InputProps?.ref
+  }, /*#__PURE__*/React.createElement(TextFieldInput, {
+    type: type === 'password' ? 'password' : 'text',
+    ref: inputRef
+    // NOTE: on the non-wip version we would simply need to spread inputProps,
+    // but now that we are using an InputBase we have to pass the 'inputProps'
+    // prop explicitly. Otherwise, we get the error: "MUI: Unable to find the input element..."
+    ,
+    inputProps: _objectSpread({}, inputProps),
+    readOnly: props.selectOnlyMode,
+    disabled: disabled,
+    maxLength: maxLength
+    //TODO this is not the best solution as we are overriding onInput handler that could be potentially passed from inputProps
+    ,
+    onInput: uppercase ? onInputUpperCaseHandler : undefined
+    // Needed for example for the multi Autocomplete since
+    // it relies on startAdornment to render the tags
+    ,
+    startAdornment: props.InputProps.startAdornment // NOTE: this is not in the non-wip version
+  }), !hideDescription && /*#__PURE__*/React.createElement(TextFieldDescription, {
+    description: desc,
+    value: value
+  }), endTextAdornment && /*#__PURE__*/React.createElement(TextFieldTextAdornment, null, endTextAdornment)), endAdornment, barcodeScanner && !disabled && /*#__PURE__*/React.createElement(EAMBarcodeScanner, {
+    onChange: onChange
+  }), link && /*#__PURE__*/React.createElement(EAMLink, {
+    link: link,
+    value: value
+  })), errorText && /*#__PURE__*/React.createElement("div", {
+    style: divErrorStyle
+  }, errorText));
+};
+export default TextField;

--- a/dist/ui/components/inputs-ng/wip/TextFieldInput.js
+++ b/dist/ui/components/inputs-ng/wip/TextFieldInput.js
@@ -1,0 +1,37 @@
+import { styled } from '@mui/material/styles';
+import InputBase from '@mui/material/InputBase';
+
+// NOTE: on the non-wip version we use 'input' instead of 'InputBase'
+// but InputBase is a simple wrapper around 'input' that gives us more options
+// like the startAdornment needed for the multiple autocomplete
+var TextFieldInput = styled(InputBase)(function (_ref) {
+  var theme = _ref.theme;
+  return {
+    '&': {
+      display: "inline-flex",
+      // NOTE: on the non-wip version this is "block"
+      width: "100%",
+      boxSizing: "border-box",
+      paddingLeft: 10,
+      fontSize: "15px",
+      lineHeight: 1.5,
+      color: "#495057",
+      backgroundClip: "padding-box",
+      border: "1px solid #e0e0e0",
+      borderRadius: "4px",
+      backgroundColor: "#fafafa",
+      height: 38,
+      fontWeight: 300,
+      fontFamily: "'Roboto', sans-serif"
+    },
+    '&:focus': {
+      outline: "2px solid ".concat(theme.palette.primary.main),
+      backgroundColor: "#fff"
+    },
+    '&:disabled': {
+      backgroundColor: "#f5f5f5",
+      border: "1px dashed #eee"
+    }
+  };
+});
+export default TextFieldInput;

--- a/src/ui/components/inputs-ng/EAMTextField.js
+++ b/src/ui/components/inputs-ng/EAMTextField.js
@@ -5,7 +5,7 @@ import TextField from './components/TextField';
 
 const EAMTextField = (props) => {
 
-    const {value, onChange, onChangeInput, validator} = props;
+    const { value, onChange, onChangeInput, validator, onBlur } = props;
     const [inputValue, setInputValue] = useState(value || '');
 
     useEffect(() => setInputValue(value || ''), [value]);
@@ -16,7 +16,7 @@ const EAMTextField = (props) => {
             setInputValue(event.target.value);
             onChangeInput?.(event.target.value);
         },
-        onBlur: () => {
+        onBlur: (event) => {
             if (inputValue !== value) {
                 if (!validator || validator(inputValue)) {
                     onChange?.(inputValue)
@@ -24,6 +24,7 @@ const EAMTextField = (props) => {
                     setInputValue(value)
                 }
             }
+            onBlur?.(event);
         },
         value: inputValue,
     };

--- a/src/ui/components/inputs-ng/wip/EAMAutocomplete.js
+++ b/src/ui/components/inputs-ng/wip/EAMAutocomplete.js
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import useFetchAutocompleteOptions from '../hooks/useFetchAutocompleteOptions';
+import {
+    areEqual,
+    componentsProps,
+    renderOptionHandler,
+} from '../tools/input-tools';
+import EAMBaseInput from '../components/EAMBaseInput';
+import TextField from './TextField';
+import { saveHistory, HISTORY_ID_PREFIX } from '../tools/history-tools';
+import Chip from '@mui/material/Chip';
+
+const filter = createFilterOptions();
+
+// TODO: this component is an extension of the EAMAutocomplete that supports
+// multiple values. Although it is expected to still work the same for single
+// values, it should be re-tested with them to make sure it still works as before.
+const EAMAutocomplete = (props) => {
+    // NOTE: the 'multiple' and 'tagLabelKey' props is not in the non-wip version
+    let {
+        autocompleteHandler,
+        autocompleteHandlerParams,
+        value,
+        desc,
+        id,
+        renderValue,
+        onChange,
+        multiple,
+        tagLabelKey, // use it if the option object is not using 'code'
+        creatable,
+    } = props;
+
+    // NOTE: this logic is not in the non-wip version
+    const optionValueKey = tagLabelKey ? tagLabelKey : 'code';
+
+    let [inputValue, setInputValue] = useState('');
+    let [open, setOpen] = useState(false);
+    let [fetchedOptions, loading] = useFetchAutocompleteOptions(
+        autocompleteHandler,
+        autocompleteHandlerParams,
+        inputValue,
+        value,
+        open,
+        id
+    );
+
+    const getOptionLabelHandler = (option) => {
+        // NOTE: we adapt if the option object is not using 'code'
+        return option[optionValueKey] ?? option;
+    };
+
+    const onInputChangeHandler = (event, newInputValue) => {
+        setInputValue(newInputValue);
+        if (newInputValue !== value && desc) {
+            onChange({ desc: '' });
+        }
+    };
+
+    const onChangeHandler = (event, newValue, reason) => {
+        if (reason === 'clear' || reason === 'createOption') {
+            // Cases handled by the onCloseHandler
+            return;
+        }
+
+        saveHistory(HISTORY_ID_PREFIX + id, newValue.code, newValue.desc);
+
+        onChange(newValue);
+
+        // Don't bubble up any events (won't trigger a save when we select something by pressing enter)
+        event.stopPropagation();
+        event.preventDefault();
+    };
+
+    const onCloseHandler = (event, reason) => {
+        setOpen(false);
+        // Only to be fired when we blur, press ESC or hit enter and the
+        // inputValue is different than the original value
+        if (
+            ['blur', 'escape', 'createOption'].includes(reason) &&
+            inputValue !== value &&
+            !multiple // avoids adding a tag // NOTE: this is not in the non-wip version
+        ) {
+            // TODO: validation if inputValue is not empty
+            onChange({ code: inputValue });
+        }
+    };
+
+    // NOTE: this handler is not in the non-wip version
+    const filterOptionsHandler = (options, params) => {
+        if (!creatable) {
+            return options;
+        }
+
+        const { inputValue } = params;
+
+        // Disallow adding the same option twice
+        if (value.some((option) => option[optionValueKey] === inputValue)) {
+            return [];
+        }
+
+        // check if input value is in the suggested options
+        const exists = options.some(
+            (option) =>
+                inputValue ===
+                (optionValueKey ? option[optionValueKey] : option)
+        );
+
+        const filtered = filter(options, params);
+
+        // if not, add it to the suggestions list
+        if (inputValue !== '' && !exists) {
+            filtered.push({
+                [optionValueKey]: inputValue,
+                desc: `Add "${inputValue}"`,
+            });
+        }
+
+        return filtered;
+    };
+
+    return (
+        <EAMBaseInput {...props}>
+            <Autocomplete
+                // Options
+                options={fetchedOptions}
+                getOptionLabel={getOptionLabelHandler}
+                renderOption={renderOptionHandler.bind(null, renderValue)}
+                // Open props
+                open={open}
+                onOpen={() => setOpen(true)}
+                onClose={onCloseHandler}
+                // On change
+                onChange={onChangeHandler}
+                onInputChange={onInputChangeHandler}
+                // Misc
+                filterOptions={filterOptionsHandler} // NOTE: this prop is different in the non-wip version
+                id={id}
+                freeSolo={true}
+                multiple={multiple} // NOTE: this prop is not in the non-wip version
+                value={value ? value : multiple ? undefined : ''} // NOTE: this cond is not in the non-wip version
+                // NOTE: this prop is not in the non-wip version
+                renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                        <Chip
+                            variant="outlined"
+                            label={
+                                optionValueKey ? option[optionValueKey] : option
+                            }
+                            {...getTagProps({ index })}
+                        />
+                    ))
+                }
+                // Visuals
+                openOnFocus // Very important, otherwise onCloseHandler won't be fired for example when we focus a field with a tab and delete its value.
+                // Funningly without this prop it still works correctly when we manually gain focus using the mouse.
+                componentsProps={componentsProps}
+                includeInputInList
+                loading={loading}
+                size="small"
+                fullWidth
+                renderInput={(params) => <TextField {...params} {...props} />}
+            />
+        </EAMBaseInput>
+    );
+};
+
+EAMAutocomplete.defaultProps = {};
+
+export default React.memo(EAMAutocomplete, areEqual);

--- a/src/ui/components/inputs-ng/wip/TextField.js
+++ b/src/ui/components/inputs-ng/wip/TextField.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import EAMBarcodeScanner from '../components/EAMBarcodeScanner';
+import EAMLink from '../components/EAMLink';
+import TextFieldInput from './TextFieldInput';
+import TextFieldTextAdornment from '../components/TextFieldTextAdornment';
+import TextFieldDescription from '../components/TextFieldDescription';
+
+const divInputStyle = {
+    flex: "1 1 auto",
+    position: "relative"
+}
+
+const divInputContainerStyle = {
+    flex: "1 1 auto",
+    display: "flex",
+    alignItems: "center",
+}
+
+const divRootContainerStyle = {
+    flex: "1 1 auto",
+    display: "flex",
+    flexDirection: "column"
+}
+
+const divErrorStyle = {
+    margin: 3, 
+    color: "red",
+    fontSize: 12
+}
+
+const TextField = (props) => {
+
+    let {desc, value,  
+        barcodeScanner, link, 
+        onChange,       
+        inputProps, 
+        inputRef,
+        endTextAdornment, endAdornment,
+        hideDescription, disabled, maxLength, uppercase, errorText, style, type} = props;
+
+    const onInputUpperCaseHandler = event => {
+        var input = event.target;
+        var start = input.selectionStart;
+        var end = input.selectionEnd;
+        input.value = input.value.toLocaleUpperCase();
+        input.setSelectionRange(start, end);
+    }
+
+    return (
+        <div style={{...divRootContainerStyle, ...style}}>
+            <div style={divInputContainerStyle}>
+                <div style={divInputStyle} ref={props.InputProps?.ref}>
+                    <TextFieldInput type={type === 'password' ? 'password' : 'text'} 
+                                    ref={inputRef} 
+                                    // NOTE: on the non-wip version we would simply need to spread inputProps,
+                                    // but now that we are using an InputBase we have to pass the 'inputProps'
+                                    // prop explicitly. Otherwise, we get the error: "MUI: Unable to find the input element..."
+                                    inputProps={{ ...inputProps }}
+                                    readOnly={props.selectOnlyMode}
+                                    disabled={disabled} 
+                                    maxLength={maxLength}
+                                    //TODO this is not the best solution as we are overriding onInput handler that could be potentially passed from inputProps
+                                    onInput={uppercase ? onInputUpperCaseHandler : undefined}
+                                    // Needed for example for the multi Autocomplete since
+                                    // it relies on startAdornment to render the tags
+                                    startAdornment={props.InputProps.startAdornment} // NOTE: this is not in the non-wip version
+                    />
+                    {!hideDescription &&<TextFieldDescription
+                        description = {desc}
+                        value = {value}
+                    />}
+                    {endTextAdornment && <TextFieldTextAdornment>{endTextAdornment}</TextFieldTextAdornment>}
+                </div>
+                {endAdornment}
+                {barcodeScanner && !disabled && <EAMBarcodeScanner onChange={onChange} />}
+                {link && <EAMLink link = {link} value = {value}/>}
+            </div>
+            {errorText && <div style={divErrorStyle}>{errorText}</div>}
+        </div>
+    )
+
+}
+
+export default TextField;

--- a/src/ui/components/inputs-ng/wip/TextFieldInput.js
+++ b/src/ui/components/inputs-ng/wip/TextFieldInput.js
@@ -1,0 +1,34 @@
+import { styled } from '@mui/material/styles';
+import InputBase from '@mui/material/InputBase';
+
+// NOTE: on the non-wip version we use 'input' instead of 'InputBase'
+// but InputBase is a simple wrapper around 'input' that gives us more options
+// like the startAdornment needed for the multiple autocomplete
+const TextFieldInput = styled(InputBase)(({theme}) => ({
+    '&': {
+        display: "inline-flex", // NOTE: on the non-wip version this is "block"
+        width: "100%",
+        boxSizing: "border-box",
+        paddingLeft: 10,
+        fontSize: "15px",
+        lineHeight: 1.5,
+        color: "#495057",
+        backgroundClip: "padding-box",
+        border: "1px solid #e0e0e0",
+        borderRadius: "4px",
+        backgroundColor: "#fafafa",
+        height: 38,
+        fontWeight: 300,
+        fontFamily: "'Roboto', sans-serif"
+    },
+    '&:focus': {
+        outline: `2px solid ${theme.palette.primary.main}`,
+        backgroundColor: "#fff"
+    },
+    '&:disabled': {
+        backgroundColor: "#f5f5f5",
+        border: "1px dashed #eee"
+    }
+}))
+
+export default TextFieldInput;


### PR DESCRIPTION
The multi autocomplete is considered WIP, but it was built as an extension of the current EAMAutocomplete, so it should not be hard to merge the two. It contains comments on most (if not all) the parts that differ from the current EAMAutocomplete.

The createOnChangeHandler now resets 'desc' and 'org' values when only the value corresponding to 'valueKey' was updated. Also, it now allows additional arguments to be passed to the updating function.

Additionally, there is now a 'createOnChangeHandlerObjectUpdate' that can be used when the updating function expects an object as its first argument (as opposed to a key and a value arguments).