### PR TITLE
[EAM-2560] Avoid setting the value to undefined

### DIFF
--- a/dist/ui/components/inputs-ng/EAMTextField.js
+++ b/dist/ui/components/inputs-ng/EAMTextField.js
@@ -15,12 +15,13 @@ var EAMTextField = function EAMTextField(props) {
     onChangeInput = props.onChangeInput,
     validator = props.validator,
     _onBlur = props.onBlur;
-  var _useState = useState(value || ''),
+  var valueOrEmptyString = value || '';
+  var _useState = useState(valueOrEmptyString),
     _useState2 = _slicedToArray(_useState, 2),
     inputValue = _useState2[0],
     setInputValue = _useState2[1];
   useEffect(function () {
-    return setInputValue(value || '');
+    return setInputValue(valueOrEmptyString);
   }, [value]);
 
   // TODO: to be reviewed
@@ -36,7 +37,7 @@ var EAMTextField = function EAMTextField(props) {
           onChange?.(inputValue);
         } else {
           // Revert to original value if validation fails
-          setInputValue(value);
+          setInputValue(valueOrEmptyString);
         }
       }
       _onBlur?.(event);

--- a/src/ui/components/inputs-ng/EAMTextField.js
+++ b/src/ui/components/inputs-ng/EAMTextField.js
@@ -6,9 +6,10 @@ import TextField from './components/TextField';
 const EAMTextField = (props) => {
 
     const { value, onChange, onChangeInput, validator, onBlur } = props;
-    const [inputValue, setInputValue] = useState(value || '');
+    const valueOrEmptyString = value || '';
+    const [inputValue, setInputValue] = useState(valueOrEmptyString);
 
-    useEffect(() => setInputValue(value || ''), [value]);
+    useEffect(() => setInputValue(valueOrEmptyString), [value]);
 
     // TODO: to be reviewed
     const inputProps = {
@@ -23,7 +24,7 @@ const EAMTextField = (props) => {
                     onChange?.(inputValue)
                 } else {
                     // Revert to original value if validation fails
-                    setInputValue(value)
+                    setInputValue(valueOrEmptyString)
                 }
             }
             onBlur?.(event);


### PR DESCRIPTION
This avoids the field showing a value that is not actually being stored by the component (since it is undefined) and the warning on having a component changing from controlled to uncontrolled.

Example of issue that occurred before this commit:
1) Type "xyz"
2) Validator function that checks for a number input fails
3) Field will still shows "xyz" to the user
    BUT the component's value is actually set to undefined