### PR TITLE
[COCO-282] Add block and disable scroll up to grid

### DIFF
--- a/dist/ui/components/grids/eam/EAMGrid.js
+++ b/dist/ui/components/grids/eam/EAMGrid.js
@@ -13,7 +13,8 @@ var EAMGrid = function EAMGrid(props) {
   var getRowProps = props.getRowProps,
       getCellProps = props.getCellProps,
       rowsPerPageOptionsComputed = props.rowsPerPageOptionsComputed,
-      customFooterOptions = props.customFooterOptions;
+      customFooterOptions = props.customFooterOptions,
+      disableScrollUp = props.disableScrollUp;
 
   var _useContext = useContext(EAMGridContext),
       dataspies = _useContext.dataspies,
@@ -32,7 +33,8 @@ var EAMGrid = function EAMGrid(props) {
       totalRecords = _useContext.totalRecords,
       tableInstance = _useContext.tableInstance,
       loading = _useContext.loading,
-      loadingExportToCSV = _useContext.loadingExportToCSV;
+      loadingExportToCSV = _useContext.loadingExportToCSV,
+      blockGrid = _useContext.blockGrid;
 
   return /*#__PURE__*/React.createElement("div", {
     style: {
@@ -56,7 +58,7 @@ var EAMGrid = function EAMGrid(props) {
     onResetFilters: handleResetFilters
   }), /*#__PURE__*/React.createElement(BlockUi, {
     tag: "div",
-    blocking: loading,
+    blocking: loading || blockGrid,
     style: {
       height: "100%",
       display: "flex",
@@ -67,7 +69,8 @@ var EAMGrid = function EAMGrid(props) {
     loading: loading,
     tableInstance: tableInstance,
     getRowProps: getRowProps,
-    getCellProps: getCellProps
+    getCellProps: getCellProps,
+    disableScrollUp: disableScrollUp
   })), /*#__PURE__*/React.createElement(EAMGridFooter, null, /*#__PURE__*/React.createElement(Box, {
     flex: "1",
     display: "flex"

--- a/dist/ui/components/grids/eam/EAMGridContext.js
+++ b/dist/ui/components/grids/eam/EAMGridContext.js
@@ -109,7 +109,8 @@ export var EAMGridContextProvider = function EAMGridContextProvider(props) {
       _props$filterProcesso = props.filterProcessor,
       filterProcessor = _props$filterProcesso === void 0 ? function (e) {
     return e;
-  } : _props$filterProcesso;
+  } : _props$filterProcesso,
+      blockGrid = props.blockGrid;
 
   var _useState = useState(0),
       _useState2 = _slicedToArray(_useState, 2),
@@ -413,7 +414,8 @@ export var EAMGridContextProvider = function EAMGridContextProvider(props) {
     initialFilters: initialFilters,
     handleResetFilters: handleResetFilters,
     handleExportToCSV: handleExportToCSV,
-    loadingExportToCSV: loadingExportToCSV
+    loadingExportToCSV: loadingExportToCSV,
+    blockGrid: blockGrid
   };
   return /*#__PURE__*/React.createElement(EAMGridContext.Provider, {
     value: context

--- a/dist/ui/components/grids/eam/EAMGridMain.js
+++ b/dist/ui/components/grids/eam/EAMGridMain.js
@@ -99,7 +99,7 @@ var EAMGridMain = function EAMGridMain(props) {
     });
 
     if (_list && !disableScrollUp) {
-      _list && _list.recomputeRowHeights();
+      _list.recomputeRowHeights();
 
       _list.scrollToRow(0);
     }

--- a/dist/ui/components/grids/eam/EAMGridMain.js
+++ b/dist/ui/components/grids/eam/EAMGridMain.js
@@ -76,7 +76,8 @@ var EAMGridMain = function EAMGridMain(props) {
       _props$BodyCellCompon = props.BodyCellComponent,
       BodyCellComponent = _props$BodyCellCompon === void 0 ? DefaultBodyCellComponent : _props$BodyCellCompon,
       _props$HeadCellCompon = props.HeadCellComponent,
-      HeadCellComponent = _props$HeadCellCompon === void 0 ? DefaultHeadCellComponent : _props$HeadCellCompon;
+      HeadCellComponent = _props$HeadCellCompon === void 0 ? DefaultHeadCellComponent : _props$HeadCellCompon,
+      disableScrollUp = props.disableScrollUp;
   var getTableProps = tableInstance.getTableProps,
       getTableBodyProps = tableInstance.getTableBodyProps,
       headerGroups = tableInstance.headerGroups,
@@ -97,7 +98,7 @@ var EAMGridMain = function EAMGridMain(props) {
       return _cache.clear(i);
     });
 
-    if (_list) {
+    if (_list && !disableScrollUp) {
       _list && _list.recomputeRowHeights();
 
       _list.scrollToRow(0);
@@ -230,7 +231,7 @@ var EAMGridMain = function EAMGridMain(props) {
       deferredMeasurementCache: _cache,
       overscanRowCount: 10,
       rowCount: rows.length,
-      rowHeight: _cache.rowHeight,
+      rowHeight: _cache?.rowHeight,
       rowRenderer: RenderRow,
       width: width,
       height: height

--- a/src/ui/components/grids/eam/EAMGrid.js
+++ b/src/ui/components/grids/eam/EAMGrid.js
@@ -16,6 +16,7 @@ const EAMGrid = (props) => {
         getCellProps,
         rowsPerPageOptionsComputed,
         customFooterOptions,
+        disableScrollUp,
     } = props;
     const {
         dataspies,
@@ -35,6 +36,7 @@ const EAMGrid = (props) => {
         tableInstance,
         loading,
         loadingExportToCSV,
+        blockGrid,
     } = useContext(EAMGridContext);
 
     return (
@@ -53,12 +55,13 @@ const EAMGrid = (props) => {
                 onDataspyChange={handleDataspyChange}
                 onResetFilters={handleResetFilters}
             />
-            <BlockUi tag="div" blocking={loading} style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <BlockUi tag="div" blocking={loading || blockGrid} style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
                 <EAMGridMain
                     loading={loading}
                     tableInstance={tableInstance}
                     getRowProps={getRowProps}
                     getCellProps={getCellProps}
+                    disableScrollUp={disableScrollUp}
                 />
             </BlockUi>
             <EAMGridFooter>

--- a/src/ui/components/grids/eam/EAMGridContext.js
+++ b/src/ui/components/grids/eam/EAMGridContext.js
@@ -99,6 +99,7 @@ export const EAMGridContextProvider = (props) => {
         processData,
         sortByProcessor = (e) => e,
         filterProcessor = (e) => e,
+        blockGrid,
     } = props;
     const [pageIndex, setPageIndex] = useState(0);
     const [selectedDataspy, setSelectedDataspy] = useState(undefined);
@@ -422,6 +423,7 @@ export const EAMGridContextProvider = (props) => {
         handleResetFilters,
         handleExportToCSV,
         loadingExportToCSV,
+        blockGrid,
     };
 
     return (

--- a/src/ui/components/grids/eam/EAMGridMain.js
+++ b/src/ui/components/grids/eam/EAMGridMain.js
@@ -67,6 +67,7 @@ const EAMGridMain = (props) => {
         TableComponent = DefaultTableComponent,
         BodyCellComponent = DefaultBodyCellComponent,
         HeadCellComponent = DefaultHeadCellComponent,
+        disableScrollUp,
     } = props;
 
     const {
@@ -88,7 +89,7 @@ const EAMGridMain = (props) => {
 
     useEffect(() => {
         rows.forEach((_, i) => _cache.clear(i));
-        if (_list) {
+        if (_list && !disableScrollUp) {
             _list && _list.recomputeRowHeights();
             _list.scrollToRow(0);
         }
@@ -196,7 +197,7 @@ const EAMGridMain = (props) => {
                                             deferredMeasurementCache={_cache}
                                             overscanRowCount={10}
                                             rowCount={rows.length}
-                                            rowHeight={_cache.rowHeight}
+                                            rowHeight={_cache?.rowHeight}
                                             rowRenderer={RenderRow}
                                             width={width}
                                             height={height}

--- a/src/ui/components/grids/eam/EAMGridMain.js
+++ b/src/ui/components/grids/eam/EAMGridMain.js
@@ -90,7 +90,7 @@ const EAMGridMain = (props) => {
     useEffect(() => {
         rows.forEach((_, i) => _cache.clear(i));
         if (_list && !disableScrollUp) {
-            _list && _list.recomputeRowHeights();
+            _list.recomputeRowHeights();
             _list.scrollToRow(0);
         }
     }, [rows]);


### PR DESCRIPTION
By adding block to the API we can now explicitly block the grid from user interaction. A use case is while a cell is saving a new value to the server according to the user input.

The disable scroll up allows to avoid the scrolling up to the first row of the grid whenever the rows update. This is specially useful when the update was not meaningful to an extent that the grid needs to be scrolled up.

Also, added a check for whether cache is defined before checking the height. This is helpful mostly for development so that the app does not crash on a live reload.

Related MR:
- https://gitlab.cern.ch/eis/amm/trackit-frontend/-/merge_requests/33