### PR TITLE
[EAM-2910] Fetch Track title when attaching an IS to a Track

### DIFF
--- a/dist/ui/components/muiinputs/EAMAutocomplete.js
+++ b/dist/ui/components/muiinputs/EAMAutocomplete.js
@@ -188,7 +188,9 @@ var EAMAutocomplete = /*#__PURE__*/function (_EAMBaseInput) {
               _this.onChangeHandler(valueFound.code, valueFound);
             }
           });
-        })["catch"](function (error) {});
+        })["catch"](function (error) {
+          _this.onChangeHandler("", "");
+        });
       }, 200);
     };
     _this.handleChange = function (event, _ref3) {

--- a/src/ui/components/muiinputs/EAMAutocomplete.js
+++ b/src/ui/components/muiinputs/EAMAutocomplete.js
@@ -161,7 +161,9 @@ class EAMAutocomplete extends EAMBaseInput {
                         }
                     );
                 })
-                .catch((error) => {});
+                .catch((error) => {
+                    this.onChangeHandler("", "");
+                });
         }, 200);
     };
 


### PR DESCRIPTION
# Description

This PR resolves issue EAM-2910. Autocomplete implementation for Track IDs. This change allows to update of the state in case of an error while fetching the track ids, so that the state is always up to date and does not store a redundant value.

Fixes #EAM-2910

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings