### PR TITLE
[COCO-479] When a Grid filter is based on a LoV, make it a multiselection one

### DIFF
--- a/dist/ui/components/eamgrid/lib/filtering.js
+++ b/dist/ui/components/eamgrid/lib/filtering.js
@@ -39,7 +39,6 @@ export function setFilter(filter, dataType) {
     // Creation of new filter
     newFilter = _objectSpread({
       operator: getDefaultFilterOperator(dataType),
-      fieldValue: undefined,
       joiner: 'AND'
     }, filter);
   }

--- a/dist/ui/components/eamgrid/lib/filtering.js
+++ b/dist/ui/components/eamgrid/lib/filtering.js
@@ -39,7 +39,7 @@ export function setFilter(filter, dataType) {
     // Creation of new filter
     newFilter = _objectSpread({
       operator: getDefaultFilterOperator(dataType),
-      fieldValue: '',
+      fieldValue: undefined,
       joiner: 'AND'
     }, filter);
   }

--- a/dist/ui/components/grids/GridTools.js
+++ b/dist/ui/components/grids/GridTools.js
@@ -7,33 +7,42 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 import queryString from 'query-string';
 var FILTER_SEPARATOR = ':::';
 var VALUE_SEPARATOR = ':';
+var JOINER_SEPARATOR = '^';
+var ARRAY_SEPARATOR = '$$';
 var OPERATOR_SEPARATOR = '|||';
 var parseGridFilters = function parseGridFilters(gridFiltersString) {
   var adaptGridFilters = function adaptGridFilters(_ref) {
     var _ref2 = _slicedToArray(_ref, 2),
       code = _ref2[0],
       value = _ref2[1];
-    var _ref3 = value && value.split(OPERATOR_SEPARATOR),
+    var _ref3 = value && value.split(JOINER_SEPARATOR),
       _ref4 = _slicedToArray(_ref3, 2),
       val = _ref4[0],
-      operator = _ref4[1];
+      joiner = _ref4[1];
+    var _ref5 = joiner && joiner.split(OPERATOR_SEPARATOR),
+      _ref6 = _slicedToArray(_ref5, 2),
+      joinerVal = _ref6[0],
+      operator = _ref6[1];
     return {
       fieldName: code,
       fieldValue: val,
-      operator: operator || 'EQUALS',
-      joiner: 'AND'
+      operator: operator || "EQUALS",
+      joiner: joinerVal || "AND",
+      leftParenthesis: false,
+      rightParenthesis: false
     };
   };
   try {
-    return gridFiltersString ? gridFiltersString.split(FILTER_SEPARATOR).filter(Boolean).map(function (gridFilter) {
+    return gridFiltersString.split(FILTER_SEPARATOR).filter(Boolean).map(function (gridFilter) {
       return gridFilter.split(VALUE_SEPARATOR);
-    }).map(adaptGridFilters) : [];
+    }).map(adaptGridFilters);
   } catch (err) {
     return [];
   }
 };
 var stringifyGridFilter = function stringifyGridFilter(gridFilter) {
-  return gridFilter.fieldValue ? gridFilter.fieldName + VALUE_SEPARATOR + (gridFilter.fieldValue || '') + OPERATOR_SEPARATOR + gridFilter.operator : '';
+  var fieldValue = gridFilter.fieldValue?.join?.(ARRAY_SEPARATOR) ?? gridFilter.fieldValue;
+  return fieldValue ? gridFilter.fieldName + VALUE_SEPARATOR + (fieldValue || '') + JOINER_SEPARATOR + gridFilter.joiner + OPERATOR_SEPARATOR + (gridFilter.operator || '=') : '';
 };
 var stringifyGridFilters = function stringifyGridFilters() {
   var gridFilters = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];

--- a/dist/ui/components/grids/eam/utils.js
+++ b/dist/ui/components/grids/eam/utils.js
@@ -21,6 +21,7 @@ import { DatePicker, DateTimePicker } from "@material-ui/pickers";
 import { Clear as ClearIcon, InsertInvitation as CalendarIcon, Cancel as CancelIcon } from "@material-ui/icons";
 import { useAsyncDebounce, useMountedLayoutEffect } from "react-table";
 import { format as formatDate } from "date-fns";
+var ARRAY_SEPARATOR = "$$";
 var BootstrapInput = withStyles(function (theme) {
   return {
     root: {
@@ -365,6 +366,31 @@ var EAMFilterField = function EAMFilterField(_ref6) {
     setLocalFilter(filter);
     debouncedSetFilter(filter);
   }, [debouncedSetFilter]);
+
+  //To set the filter labels and the multiFilterValues on initial render
+  useEffect(function () {
+    if (filter?.fieldValue.includes(ARRAY_SEPARATOR)) {
+      var fieldValues = filter?.fieldValue.split(ARRAY_SEPARATOR);
+      var uniqueFieldValues = Array.from(new Set(fieldValues));
+      var labels = uniqueFieldValues.map(function (code) {
+        var fieldvalueOption = column.selectOptions.find(function (option) {
+          return option.code === code;
+        });
+        return fieldvalueOption.desc;
+      });
+      setMultiSelectFilter(function (prevMultiSelectFilter) {
+        return _objectSpread({}, prevMultiSelectFilter, {
+          fieldValue: uniqueFieldValues
+        });
+      });
+      setMultiFilterLabel(labels);
+    } else if (column?.selectOptions) {
+      var fieldvalueOption = column.selectOptions.find(function (option) {
+        return option.code === filter?.fieldValue;
+      });
+      setMultiFilterLabel([fieldvalueOption?.desc] || []);
+    }
+  }, []);
   var updateMultiSelectFilter = React.useCallback(function (fieldValueFilter) {
     setMultiSelectFilter(function (prev) {
       return _objectSpread({}, prev, {

--- a/src/ui/components/eamgrid/lib/filtering.js
+++ b/src/ui/components/eamgrid/lib/filtering.js
@@ -39,7 +39,7 @@ export function setFilter(filter, dataType) {
         // Creation of new filter
         newFilter = {
             operator: getDefaultFilterOperator(dataType),
-            fieldValue: '',
+            fieldValue: undefined,
             joiner: 'AND',
             ...filter
         }

--- a/src/ui/components/eamgrid/lib/filtering.js
+++ b/src/ui/components/eamgrid/lib/filtering.js
@@ -39,7 +39,6 @@ export function setFilter(filter, dataType) {
         // Creation of new filter
         newFilter = {
             operator: getDefaultFilterOperator(dataType),
-            fieldValue: undefined,
             joiner: 'AND',
             ...filter
         }

--- a/src/ui/components/grids/eam/EAMGridContext.js
+++ b/src/ui/components/grids/eam/EAMGridContext.js
@@ -11,6 +11,8 @@ import { EAMCellField, EAMFilterField, getRowAsAnObject } from "./utils";
 import useEAMGridTableInstance from "./useEAMGridTableInstance";
 import { useAsyncDebounce } from "react-table";
 
+const ARRAY_SEPARATOR = "$$";
+
 const defaultCreateColumns = ({ gridField, cellRenderer }) =>
     (gridField || [])
         .sort((a, b) => a.order - b.order)
@@ -30,8 +32,8 @@ const processFilters = (filters, filterProcessor) => {
         return filters
             .map((f) => {
                 let fieldValue = f.value.fieldValue
-                if (fieldValue && fieldValue.includes("$$")) {
-                    fieldValue = fieldValue.split("$$");
+                if (fieldValue && fieldValue.includes(ARRAY_SEPARATOR)) {
+                    fieldValue = fieldValue.split(ARRAY_SEPARATOR);
                 }
                 const filter = { ...f.value, fieldValue: fieldValue }
                 return Object.keys(filter)

--- a/src/ui/components/grids/eam/utils.js
+++ b/src/ui/components/grids/eam/utils.js
@@ -11,7 +11,6 @@ import {
     withStyles,
     Select,
     InputBase,
-    FormControlLabel,
 } from "@material-ui/core";
 import {
     ContainStart,
@@ -103,7 +102,7 @@ const isIndeterminate = (valueType) => valueType === null || valueType === CHECK
 const getEAMDefaultFilterValue = (column) => {
     const baseFitler = {
         fieldName: column.id,
-        fieldValue: undefined,
+        fieldValue: '',
         joiner: 'AND',
         operator: OPERATORS.BEGINS,
         leftParenthesis: false,
@@ -451,7 +450,7 @@ const EAMFilterField = ({ column, getDefaultValue = getEAMDefaultFilterValue }) 
                         </MenuItem>
                         )
                     )}
-                    </Select>
+                </Select>
             )
         default:
             return null;


### PR DESCRIPTION
# Description

This feature enhancement allows users to now select multiple values from a list of values in order to filter the grid. Resolves issue [COCO-479](https://its.cern.ch/jira/browse/COCO-479).

In order for this to be implemented on the frontend, the dataType of the column simply needs to be set to "__MULTISELECT".

Fixes #COCO-479

## Type of change

Please delete options that are not relevant.

- [x] Feature Enhancement

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings