### PR TITLE
EAM-2958: EAMBarcodeScanner improvement

### DIFF
--- a/dist/ui/components/inputs-ng/components/EAMBarcodeScanner.js
+++ b/dist/ui/components/inputs-ng/components/EAMBarcodeScanner.js
@@ -35,7 +35,8 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
     _useState8 = _slicedToArray(_useState7, 2),
     currentDevice = _useState8[0],
     setCurrentDevice = _useState8[1];
-  var streamReaf = useRef(null);
+  var streamRef = useRef(null);
+  var openRef = useRef(false);
   useEffect(function () {
     navigator.mediaDevices?.enumerateDevices().then(function (deviceCount) {
       if (deviceCount.length > 0 && navigator.mediaDevices.getUserMedia) {
@@ -45,15 +46,12 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
   }, []);
   var handleClickOpen = function handleClickOpen() {
     setOpen(true);
+    openRef.current = true;
   };
   var handleClose = function handleClose() {
     setOpen(false);
-    codeReader.current.reset();
-    if (streamReaf.current) {
-      streamReaf.current.getTracks().forEach(function (track) {
-        return track.stop();
-      });
-    }
+    openRef.current = false;
+    resetStreams();
   };
   var startScanner = function startScanner() {
     var devices, videoDevices, device, selectedDevice;
@@ -88,14 +86,10 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
           _context.t0 = _context["catch"](0);
           console.error(_context.t0);
         case 17:
-          _context.prev = 17;
-          handleClose();
-          return _context.finish(17);
-        case 20:
         case "end":
           return _context.stop();
       }
-    }, null, null, [[0, 14, 17, 20]], Promise);
+    }, null, null, [[0, 14]], Promise);
   };
   var startDecoding = function startDecoding(device) {
     var stream, result;
@@ -113,25 +107,30 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
           }));
         case 3:
           stream = _context2.sent;
-          streamReaf.current = stream;
+          streamRef.current = stream;
           _context2.next = 7;
           return _regeneratorRuntime().awrap(codeReader.current.decodeOnceFromStream(stream, "video"));
         case 7:
           result = _context2.sent;
           onDetectedCallback(result.text);
-          _context2.next = 14;
+          handleClose();
+          _context2.next = 15;
           break;
-        case 11:
-          _context2.prev = 11;
+        case 12:
+          _context2.prev = 12;
           _context2.t0 = _context2["catch"](0);
           console.error(_context2.t0);
-        case 14:
-          ;
         case 15:
+          _context2.prev = 15;
+          if (!openRef.current) resetStreams();
+          return _context2.finish(15);
+        case 18:
+          ;
+        case 19:
         case "end":
           return _context2.stop();
       }
-    }, null, null, [[0, 11]], Promise);
+    }, null, null, [[0, 12, 15, 18]], Promise);
   };
   var handleDeviceChange = function handleDeviceChange(device) {
     setCurrentDevice(device);
@@ -147,6 +146,14 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
   if (!showBarcodeButton) {
     return React.Fragment;
   }
+  var resetStreams = function resetStreams() {
+    codeReader.current.reset();
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(function (track) {
+        return track.stop();
+      });
+    }
+  };
 
   // Active quagga when support for user media
   return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement(IconButton, {

--- a/dist/ui/components/inputs-ng/components/EAMBarcodeScanner.js
+++ b/dist/ui/components/inputs-ng/components/EAMBarcodeScanner.js
@@ -1,3 +1,5 @@
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, defineProperty = Object.defineProperty || function (obj, key, desc) { obj[key] = desc.value; }, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return defineProperty(generator, "_invoke", { value: makeInvokeMethod(innerFn, self, context) }), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; defineProperty(this, "_invoke", { value: function value(method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); } }); } function makeInvokeMethod(innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; } function maybeInvokeDelegate(delegate, context) { var methodName = context.method, method = delegate.iterator[methodName]; if (undefined === method) return context.delegate = null, "throw" === methodName && delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method) || "return" !== methodName && (context.method = "throw", context.arg = new TypeError("The iterator does not provide a '" + methodName + "' method")), ContinueSentinel; var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, defineProperty(Gp, "constructor", { value: GeneratorFunctionPrototype, configurable: !0 }), defineProperty(GeneratorFunctionPrototype, "constructor", { value: GeneratorFunction, configurable: !0 }), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (val) { var object = Object(val), keys = []; for (var key in object) keys.push(key); return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
@@ -33,6 +35,7 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
     _useState8 = _slicedToArray(_useState7, 2),
     currentDevice = _useState8[0],
     setCurrentDevice = _useState8[1];
+  var streamReaf = useRef(null);
   useEffect(function () {
     navigator.mediaDevices?.enumerateDevices().then(function (deviceCount) {
       if (deviceCount.length > 0 && navigator.mediaDevices.getUserMedia) {
@@ -46,44 +49,91 @@ var EAMBarcodeScanner = function EAMBarcodeScanner(props) {
   var handleClose = function handleClose() {
     setOpen(false);
     codeReader.current.reset();
+    if (streamReaf.current) {
+      streamReaf.current.getTracks().forEach(function (track) {
+        return track.stop();
+      });
+    }
   };
   var startScanner = function startScanner() {
-    navigator.mediaDevices.getUserMedia({
-      video: true
-    }).then(function (data) {
-      navigator.mediaDevices.enumerateDevices().then(function (devices) {
-        if (devices.length > 0) {
-          var videoDevices = devices.filter(function (d) {
+    var devices, videoDevices, device, selectedDevice;
+    return _regeneratorRuntime().async(function startScanner$(_context) {
+      while (1) switch (_context.prev = _context.next) {
+        case 0:
+          _context.prev = 0;
+          _context.next = 3;
+          return _regeneratorRuntime().awrap(navigator.mediaDevices.enumerateDevices());
+        case 3:
+          devices = _context.sent;
+          if (!(devices.length > 0)) {
+            _context.next = 12;
+            break;
+          }
+          videoDevices = devices.filter(function (d) {
             return d.kind === 'videoinput';
           });
-          var device = localStorage.getItem("videoInputDevice");
-          var selectedDevice = videoDevices.find(function (d) {
+          device = localStorage.getItem("videoInputDevice");
+          selectedDevice = videoDevices.find(function (d) {
             return d?.deviceId === device;
           })?.deviceId ?? videoDevices[0].deviceId;
           setVideoInputDevices(videoDevices);
           setCurrentDevice(selectedDevice);
-          startDecoding(selectedDevice);
-        }
-      })["catch"](function (error) {
-        console.error(error);
-        handleClose();
-      });
-    })["catch"](function (error) {
-      console.error(error);
-      handleClose();
-    });
+          _context.next = 12;
+          return _regeneratorRuntime().awrap(startDecoding(selectedDevice));
+        case 12:
+          _context.next = 17;
+          break;
+        case 14:
+          _context.prev = 14;
+          _context.t0 = _context["catch"](0);
+          console.error(_context.t0);
+        case 17:
+          _context.prev = 17;
+          handleClose();
+          return _context.finish(17);
+        case 20:
+        case "end":
+          return _context.stop();
+      }
+    }, null, null, [[0, 14, 17, 20]], Promise);
   };
   var startDecoding = function startDecoding(device) {
-    codeReader.current.decodeFromInputVideoDevice(device, "video").then(function (result) {
-      onDetectedCallback(result.text);
-      codeReader.current.reset();
-      handleClose();
-    })["catch"](function (err) {
-      return console.error(err);
-    });
+    var stream, result;
+    return _regeneratorRuntime().async(function startDecoding$(_context2) {
+      while (1) switch (_context2.prev = _context2.next) {
+        case 0:
+          _context2.prev = 0;
+          _context2.next = 3;
+          return _regeneratorRuntime().awrap(navigator.mediaDevices.getUserMedia({
+            video: {
+              deviceId: {
+                exact: device
+              }
+            }
+          }));
+        case 3:
+          stream = _context2.sent;
+          streamReaf.current = stream;
+          _context2.next = 7;
+          return _regeneratorRuntime().awrap(codeReader.current.decodeOnceFromStream(stream, "video"));
+        case 7:
+          result = _context2.sent;
+          onDetectedCallback(result.text);
+          _context2.next = 14;
+          break;
+        case 11:
+          _context2.prev = 11;
+          _context2.t0 = _context2["catch"](0);
+          console.error(_context2.t0);
+        case 14:
+          ;
+        case 15:
+        case "end":
+          return _context2.stop();
+      }
+    }, null, null, [[0, 11]], Promise);
   };
   var handleDeviceChange = function handleDeviceChange(device) {
-    codeReader.current.reset();
     setCurrentDevice(device);
     startDecoding(device);
     localStorage.setItem("videoInputDevice", device);

--- a/src/ui/components/inputs-ng/components/EAMBarcodeScanner.js
+++ b/src/ui/components/inputs-ng/components/EAMBarcodeScanner.js
@@ -18,6 +18,7 @@ const EAMBarcodeScanner = (props) => {
     let [showBarcodeButton, setShowBarcodeButton] = useState(false);
     const [videoInputDevices, setVideoInputDevices] = useState([]);
     const [currentDevice, setCurrentDevice] = useState("");
+    const streamReaf = useRef(null);
 
     useEffect(() => {
         navigator.mediaDevices?.enumerateDevices().then((deviceCount) => {
@@ -34,6 +35,9 @@ const EAMBarcodeScanner = (props) => {
     const handleClose = () => {
         setOpen(false);
         codeReader.current.reset();
+        if(streamReaf.current) {
+            streamReaf.current.getTracks().forEach(track => track.stop());
+        }
     };
 
     const startScanner = async () => {
@@ -56,7 +60,9 @@ const EAMBarcodeScanner = (props) => {
 
     const startDecoding =  async (device) => {
         try {
-            let result = await codeReader.current.decodeOnceFromVideoDevice(device, "video")
+            let stream = await navigator.mediaDevices.getUserMedia({video: {deviceId: { exact: device }}});
+            streamReaf.current = stream;
+            let result = await codeReader.current.decodeOnceFromStream(stream, "video");
             onDetectedCallback(result.text);
         } catch(err) {
             console.error(err)


### PR DESCRIPTION
The callbacks have been replaced with "async await" functions. Redundant resets have been removed. Additionally, the call to the method `navigator.mediaDevices.getUserMedia({video: true})` has been deleted, as its result was not being used and the library (@zxing/library) already handles that internally.

The camera bug remains unsolved as it is dependent on the library (@zxing/library). The camera stays on even if the user clicks on cancel. This is due to a race condition. The reset function of the library is invoked before the variable this.stream is initialized, resulting in the inadequate termination of the streams (`stopStreams()`). Hence, this issue should be addressed within the library itself.

`protected stopStreams(): void { `<br />`
    if (this.stream) { `<br />`
      this.stream.getVideoTracks().forEach(t => t.stop()); `<br />`
      this.stream = undefined; `<br />`
    } `<br />`
    if (this._stopAsyncDecode === false) { `<br />`
      this.stopAsyncDecode(); `<br />`
    } `<br />`
    if (this._stopContinuousDecode === false) { `<br />`
      this.stopContinuousDecode(); `<br />`
    } `<br />`
 }`