### PR TITLE
[EAM-3125] Allow passing options (activity code, hide filled, expand options) for the checklists

### DIFF
--- a/dist/ui/components/checklists/Checklists.js
+++ b/dist/ui/components/checklists/Checklists.js
@@ -1,4 +1,5 @@
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+var _SIGNATURE_ORDER;
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
@@ -8,18 +9,18 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-function _callSuper(t, o, e) { return o = _getPrototypeOf(o), _possibleConstructorReturn(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], _getPrototypeOf(t).constructor) : o.apply(t, e)); }
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); }
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : String(i); }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
 import React, { Component } from 'react';
 import Button from '@mui/material/Button';
 import MuiExpansionPanel from '@mui/material/Accordion';
@@ -43,7 +44,7 @@ var SIGNATURE_TYPES = {
   PERFORMER_2: 'PB02',
   REVIEWER: 'RB01'
 };
-var SIGNATURE_ORDER = _defineProperty(_defineProperty(_defineProperty({}, SIGNATURE_TYPES.PERFORMER_1, 1), SIGNATURE_TYPES.PERFORMER_2, 2), SIGNATURE_TYPES.REVIEWER, 3);
+var SIGNATURE_ORDER = (_SIGNATURE_ORDER = {}, _defineProperty(_SIGNATURE_ORDER, SIGNATURE_TYPES.PERFORMER_1, 1), _defineProperty(_SIGNATURE_ORDER, SIGNATURE_TYPES.PERFORMER_2, 2), _defineProperty(_SIGNATURE_ORDER, SIGNATURE_TYPES.REVIEWER, 3), _SIGNATURE_ORDER);
 var ActivityExpansionPanel = withStyles({
   root: {
     backgroundColor: '#fafafa',
@@ -106,10 +107,11 @@ function getExpandedActivities(activities) {
 // in "Activities and Booked Labor", it will not be reflected here
 var Checklists = /*#__PURE__*/function (_Component) {
   _inherits(Checklists, _Component);
+  var _super = _createSuper(Checklists);
   function Checklists(props) {
     var _this;
     _classCallCheck(this, Checklists);
-    _this = _callSuper(this, Checklists, [props]);
+    _this = _super.call(this, props);
     _this.collapse = function (checklists, activities) {
       var maxExpandedChecklistItems = _this.props.maxExpandedChecklistItems;
       var defaultCollapse = function defaultCollapse(checklists, activities) {
@@ -263,15 +265,18 @@ var Checklists = /*#__PURE__*/function (_Component) {
         };
       });
     };
+    var _activityCode = GridTools.getURLParameterByName('activityCode');
     _this.state = {
       activities: [],
       blocking: true,
       createFollowUpActivity: null,
-      filteredActivity: null,
+      activityCode: _activityCode,
+      filteredActivity: _activityCode,
       filteredEquipment: null,
       signaturesCollapsed: {},
       checklistsHidden: {},
-      expandChecklistOptions: false
+      expandChecklistOptions: _this.parseToBoolean(GridTools.getURLParameterByName("expandOptions")),
+      hideFilledItems: _this.parseToBoolean(GridTools.getURLParameterByName("hideFilledItems"))
     };
     return _this;
   }
@@ -279,6 +284,11 @@ var Checklists = /*#__PURE__*/function (_Component) {
     key: "componentWillMount",
     value: function componentWillMount() {
       this.readActivities(this.props.workorder);
+    }
+  }, {
+    key: "parseToBoolean",
+    value: function parseToBoolean(value) {
+      return value.length === 0 ? false : value !== "false";
     }
   }, {
     key: "componentWillReceiveProps",
@@ -301,11 +311,12 @@ var Checklists = /*#__PURE__*/function (_Component) {
           return checklists.concat(activity.checklists);
         }, []);
         _this2.collapse(checklists, activities);
-        _this2.setState({
-          activities: activities,
-          blocking: false
-        }, function () {
-          if (hideFilledItems) {
+        _this2.setState(function (prevState) {
+          var newState = {
+            activities: activities,
+            blocking: false
+          };
+          if (hideFilledItems || prevState.hideFilledItems) {
             _this2.toggleFilledFilter();
           }
           if (activity) {
@@ -315,6 +326,7 @@ var Checklists = /*#__PURE__*/function (_Component) {
               }
             });
           }
+          return newState;
         });
       });
     }
@@ -645,6 +657,7 @@ var Checklists = /*#__PURE__*/function (_Component) {
       var _this8 = this;
       var _this$state = this.state,
         activities = _this$state.activities,
+        activityCode = _this$state.activityCode,
         filteredActivity = _this$state.filteredActivity,
         filteredEquipment = _this$state.filteredEquipment,
         blocking = _this$state.blocking;
@@ -721,7 +734,7 @@ var Checklists = /*#__PURE__*/function (_Component) {
         label: 'Expand Checklist Options',
         onMouseDown: this.toggleExpandChecklistOptions,
         onTouchStart: this.toggleExpandChecklistOptions
-      })), /*#__PURE__*/React.createElement("div", {
+      })), !activityCode && /*#__PURE__*/React.createElement("div", {
         style: {
           paddingLeft: 25,
           paddingRight: 25


### PR DESCRIPTION
Activity code, hide filled and expand options can now be passed as URL params:
- Activity code -> activityCode
- Hide filled -> hideFilledItems
- Expand options -> expandOptions

If an activity code is passed a an URL param the activity selector is hidden. 